### PR TITLE
Add test case for sysctl

### DIFF
--- a/engine/test_sysctl.py
+++ b/engine/test_sysctl.py
@@ -1,0 +1,19 @@
+# coding = utf-8
+# Create date: 2018-11-05
+# Author :Hailong
+
+
+def test_sysctl(ros_kvm_with_paramiko, cloud_config_url):
+    command = 'sudo cat /proc/sys/kernel/domainname'
+    feed_back = 'test'
+    client = ros_kvm_with_paramiko(cloud_config='{url}/test_sysctl.yml'.format(url=cloud_config_url))
+    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    output = stdout.read().decode('utf-8').replace('\n', '')
+    assert (feed_back == output)
+
+    command_b = 'sudo cat /proc/sys/dev/cdrom/debug'
+    feed_back_b = '1'
+    stdin, stdout, stderr = client.exec_command(command_b, timeout=10)
+    output_b = stdout.read().decode('utf-8').replace('\n', '')
+    client.close()
+    assert (feed_back_b == output_b)


### PR DESCRIPTION
Test the sysctl

The test results:
```
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /opt/pycharm_project_777, inifile:
plugins: cov-2.6.0
collected 1 item                                                               

engine/test_sysctl.py Formatting '/opt/HZ2YGC01.qcow2', fmt=qcow2 size=10737418240 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
.

========================== 1 passed in 180.40 seconds ==========================

Process finished with exit code 0
```