### PR TITLE
Add test case for start command

### DIFF
--- a/engine/test_start_commands.py
+++ b/engine/test_start_commands.py
@@ -1,0 +1,19 @@
+# coding = utf-8
+# Create date: 2018-11-05
+# Author :Hailong
+
+
+def test_start_commands(ros_kvm_with_paramiko, cloud_config_url):
+    command = 'ls /home/rancher | grep "test[0-5]"  | wc -l'
+    feed_back = '5'
+    client = ros_kvm_with_paramiko(cloud_config='{url}/test_start_commands.yml'.format(url=cloud_config_url))
+    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    output = stdout.read().decode('utf-8')
+    assert (feed_back in output)
+
+    command_b = 'docker ps | grep busybox'
+    feed_back_b = 'busybox'
+    stdin, stdout, stderr = client.exec_command(command_b, timeout=60)
+    output_b = stdout.read().decode('utf-8')
+    client.close()
+    assert (feed_back_b in output_b)


### PR DESCRIPTION
The test results:
```
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /opt/pycharm_project_777, inifile:
plugins: cov-2.6.0
collected 1 item                                                               

engine/test_start_commands.py Formatting '/opt/Y7JN2E2Q.qcow2', fmt=qcow2 size=10737418240 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
.

========================== 1 passed in 241.34 seconds ==========================

Process finished with exit code 0
```