### PR TITLE
Add test case named 'test_misc'

### DIFF
--- a/engine/test_lenient_service_parsing.py
+++ b/engine/test_lenient_service_parsing.py
@@ -1,0 +1,12 @@
+# coding = utf-8
+# Create date: 2018-11-6
+# Author :Bowen Lee
+
+
+def test_lenient_service_parsing(ros_kvm_with_paramiko, cloud_config_url):
+    command = 'sudo system-docker ps -a | grep test-parsing'
+    client = ros_kvm_with_paramiko(cloud_config='{url}/test_lenient_service_parsing.yml'.format(url=cloud_config_url))
+    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    output = stdout.read().decode('utf-8')
+    client.close()
+    assert ('test-parsing' in output)

--- a/engine/test_misc.py
+++ b/engine/test_misc.py
@@ -1,0 +1,37 @@
+# coding = utf-8
+# Create date: 2018-11-6
+# Author :Bowen Lee
+import time
+
+
+def test_misc(ros_kvm_with_paramiko, cloud_config_url):
+    command = "sudo ros env printenv FLANNEL_NETWORK"
+    client = ros_kvm_with_paramiko(cloud_config='{url}/test_misc.yml'.format(url=cloud_config_url))
+
+    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    output = stdout.read().decode('utf-8')
+    assert ('10.244.0.0/16' in output)
+
+    command_dncp = "ps -ef"
+    stdin, stdout, stderr = client.exec_command(command_dncp, timeout=10)
+    output_dncp = stdout.read().decode('utf-8')
+
+    assert ('dhcpcd -M' in output_dncp)
+
+    command_tls = "set -e -x " \
+                  "&& sudo ros tls gen --server -H localhost " \
+                  "&& sudo ros tls gen" \
+                  "&& sudo ros c set rancher.docker.tls true" \
+                  "&& sudo system-docker restart docker"
+    client.exec_command(command_tls, timeout=20)
+    time.sleep(10)
+    command_check_docker = 'docker --tlsverify version'
+    stdin, stdout, stderr = client.exec_command(command_check_docker, timeout=10)
+    output_docker_info = stdout.read().decode('utf-8')
+    assert ('Client' and 'Server' in output_docker_info)
+
+    stdin, stdout, stderr = client.exec_command('set -e -x &&'
+                                                'pidof system-dockerd', timeout=10)
+
+    assert ('1' in stdout.read().decode('utf-8'))
+    client.close()


### PR DESCRIPTION
```
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /root/tmp/pycharm_project_473, inifile:
plugins: cov-2.6.0
collected 1 item                                                               

engine/test_misc.py Formatting '/opt/PU6R0EUE.qcow2', fmt=qcow2 size=10737418240 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
.

========================== 1 passed in 226.51 seconds ==========================

Process finished with exit code 0
```