### PR TITLE
Add new test case named 'test_kernel_headers'

### DIFF
--- a/engine/test_kernel_headers.py
+++ b/engine/test_kernel_headers.py
@@ -1,0 +1,13 @@
+# coding = utf-8
+# Create date: 2018-11-6
+# Author :Bowen Lee
+
+
+def test_kernel_headers(ros_kvm_with_paramiko, cloud_config_url):
+    command = 'sudo system-docker inspect kernel-headers'
+    client = ros_kvm_with_paramiko(cloud_config='{url}/test_kernel_headers.yml'.format(url=cloud_config_url))
+
+    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    output = stdout.read().decode('utf-8')
+    client.close()
+    assert ('kernel-headers' in output)


### PR DESCRIPTION
```
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /root/tmp/pycharm_project_473, inifile:
plugins: cov-2.6.0
collected 1 item                                                               

engine/test_kernel_headers.py Formatting '/opt/6K1Z5DWP.qcow2', fmt=qcow2 size=10737418240 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
.

========================== 1 passed in 241.23 seconds ==========================

Process finished with exit code 0
```