### PR TITLE
Add test case for subdir

### DIFF
--- a/engine/test_subdir.py
+++ b/engine/test_subdir.py
@@ -1,0 +1,16 @@
+# coding = utf-8
+# Create date: 2018-11-14
+# Author :Hailong
+
+
+def test_subdir(ros_kvm_for_kernel_parameters):
+    command = 'mkdir x &&  \
+              sudo mount $(sudo ros dev LABEL=RANCHER_STATE) x &&  \
+              test -d x/ros_subdir/home/rancher;  \
+              echo $?'
+    feed_back = '0'
+    client = ros_kvm_for_kernel_parameters(kernel_parameters='rancher.state.directory=ros_subdir')
+
+    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    output = stdout.read().decode('utf-8').replace('\n', '')
+    assert (feed_back == output)


### PR DESCRIPTION
ssh://root@192.168.1.24:22/usr/bin/python3 -u /opt/pycharm_project_777/executor.py
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /opt/pycharm_project_777, inifile:
plugins: xdist-1.24.1, forked-0.2, cov-2.6.0
collected 1 item                                                               

engine/test_subdir.py Formatting '/opt/WKPS1446.qcow2', fmt=qcow2 size=10737418240 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
.

========================== 1 passed in 99.10 seconds ===========================

Process finished with exit code 0