### PR TITLE
Add test case for shared boot2docker autoformat

### DIFF
--- a/engine/test_b2d_autoformat_boot_initrd.py
+++ b/engine/test_b2d_autoformat_boot_initrd.py
@@ -1,0 +1,15 @@
+# coding = utf-8
+# Create date: 2018-11-19
+# Author :Hailong
+
+
+def test_b2d_autoformat_boot_initrd(ros_kvm_for_kernel_parameters):
+    command = 'blkid'
+    feed_back = 'B2D_STATE'
+    client = ros_kvm_for_kernel_parameters(kernel_parameters=None, b2d=True)
+
+    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    output = stdout.read().decode('utf-8')
+    client.close()
+    assert (feed_back in output)
+

--- a/engine/test_b2d_autoformat_boot_iso.py
+++ b/engine/test_b2d_autoformat_boot_iso.py
@@ -1,0 +1,14 @@
+# coding = utf-8
+# Create date: 2018-11-19
+# Author :Hailong
+
+
+def test_b2d_autoformat_boot_iso(ros_kvm_with_paramiko_b2d):
+    command = 'blkid'
+    feed_back = 'B2D_STATE'
+    client = ros_kvm_with_paramiko_b2d()
+
+    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    output = stdout.read().decode('utf-8')
+    client.close()
+    assert (feed_back in output)


### PR DESCRIPTION
```
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /opt/pycharm_project_777, inifile:
plugins: xdist-1.24.1, forked-0.2, cov-2.6.0
collected 1 item                                                               

engine/test_b2d_autoformat_boot_initrd.py .

========================== 1 passed in 50.74 seconds ===========================

Process finished with exit code 0
```

```
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /opt/pycharm_project_777, inifile:
plugins: xdist-1.24.1, forked-0.2, cov-2.6.0
collected 1 item                                                               

engine/test_b2d_autoformat_boot_iso.py Formatting '/opt/os-tests/images/5OCPEEDS_second.qcow2', fmt=qcow2 size=2147483648 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
.

========================== 1 passed in 70.84 seconds ===========================

Process finished with exit code 0
```