### PR TITLE
Add test case for oem

### DIFF
--- a/engine/test_oem.py
+++ b/engine/test_oem.py
@@ -1,0 +1,28 @@
+# coding = utf-8
+# Create date: 2018-11-20
+# Author :Hailong
+from utils.connect_to_os import executor, connection
+
+
+def test_oem(ros_kvm_return_ip, cloud_config_url):
+    client, ip = ros_kvm_return_ip(cloud_config='{url}/default.yml'.format(url=cloud_config_url))
+    c_add_ome_config = 'set -x && ' \
+                       'set -e && ' \
+                       'sudo mkfs.ext4 -L RANCHER_OEM /dev/vdb && ' \
+                       'sudo mount /dev/vdb /mnt &&' \
+                       'echo -e "#cloud-config \nrancher:\n  upgrade:\n    url: \'foo\'" > /tmp/oem-config.yml &&' \
+                       'sudo cp /tmp/oem-config.yml /mnt &&' \
+                       'sudo umount /mnt'
+    executor(client, c_add_ome_config)
+
+    executor(client, 'sudo reboot')
+
+    second_client = connection(ip)
+    c_ls_oem = 'ls /usr/share/ros/oem'
+    output_ls_oem = executor(second_client, c_ls_oem)
+    assert ('oem-config.yml' in output_ls_oem)
+
+    c_get_oem = 'sudo ros config get rancher.upgrade.url'
+    output_get_oem = executor(second_client, c_get_oem)
+    second_client.close()
+    assert ('foo' in output_get_oem)


### PR DESCRIPTION
```
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /tmp/pycharm_project_65, inifile:
plugins: cov-2.6.0
collected 1 item                                                               

engine/test_oem.py Formatting '/opt/os-tests/images/3GO5N3JS.qcow2', fmt=qcow2 size=10737418240 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
Formatting '/opt/os-tests/images/3GO5N3JS_second.qcow2', fmt=qcow2 size=2147483648 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
.

========================== 1 passed in 221.39 seconds ==========================

Process finished with exit code 0
```