### PR TITLE
Modify the common function and the test cases to use the new common functions.

### DIFF
--- a/engine/test_b2d_autoformat_boot_initrd.py
+++ b/engine/test_b2d_autoformat_boot_initrd.py
@@ -3,13 +3,15 @@
 # Author :Hailong
 
 
-def test_b2d_autoformat_boot_initrd(ros_kvm_for_kernel_parameters):
+def test_b2d_autoformat_boot_initrd(ros_kvm_init):
     command = 'blkid'
     feed_back = 'B2D_STATE'
-    client = ros_kvm_for_kernel_parameters(kernel_parameters=None, b2d=True)
+    kwargs = dict(is_b2d=True, is_kernel_parameters=True,
+                  kernel_parameters='rancher.state.dev=LABEL=RANCHER_STATE rancher.state.autoformat=[/dev/sda,/dev/vda]')
+    tuple_return = ros_kvm_init(**kwargs)
 
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     client.close()
     assert (feed_back in output)
-

--- a/engine/test_b2d_autoformat_boot_iso.py
+++ b/engine/test_b2d_autoformat_boot_iso.py
@@ -3,12 +3,13 @@
 # Author :Hailong
 
 
-def test_b2d_autoformat_boot_iso(ros_kvm_with_paramiko_b2d):
+def test_b2d_autoformat_boot_iso(ros_kvm_init):
     command = 'blkid'
     feed_back = 'B2D_STATE'
-    client = ros_kvm_with_paramiko_b2d()
-
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    kwargs = dict(is_b2d=True, is_second_hd=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     client.close()
     assert (feed_back in output)

--- a/engine/test_cloud_config_console.py
+++ b/engine/test_cloud_config_console.py
@@ -4,13 +4,16 @@
 # Author :Bowen Lee
 
 
-def test_cloud_config_console(ros_kvm_with_paramiko, cloud_config_url):
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_cloud_config_console.yml'.format(url=cloud_config_url))
-    stdin, stdout, stderr = client.exec_command('sudo ros console list | grep default', timeout=10)
+def test_cloud_config_console(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}test_cloud_config_console.yml'.format(url=cloud_config_url),
+                  is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command('sudo ros console list | grep default', timeout=60)
     output = stdout.read().decode('utf-8')
     assert ('default' in output and 'disabled' in output)
 
-    stdin, stdout, stderr = client.exec_command('sudo ros console list | grep debian', timeout=10)
+    stdin, stdout, stderr = client.exec_command('sudo ros console list | grep debian', timeout=60)
     output = stdout.read().decode('utf-8')
     client.close()
     assert ('debian' in output and 'current' in output)

--- a/engine/test_cmdline.py
+++ b/engine/test_cmdline.py
@@ -6,35 +6,39 @@ import time
 from utils.connect_to_os import connection, executor
 
 
-def test_cmdline(ros_kvm_with_paramiko, cloud_config_url):
+def test_cmdline(ros_kvm_init, cloud_config_url):
     extra_args = 'cc.hostname=nope rancher.password=three'
     args = ' --append "cc.something=yes rancher.password=two -- {extra_args}"'.format(
         extra_args=extra_args)
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url),
+                  extra_install_args=args,
+                  is_install_to_hard_drive=True)
 
-    client = ros_kvm_with_paramiko(cloud_config='{url}/default.yml'.format(url=cloud_config_url),
-                                   extra_install_args=args)
-    hostname = executor(client, 'hostname', seconds=10)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+
+    hostname = executor(client, 'hostname')
     assert ('nope\n' == hostname)
 
-    output_of_cmdline = executor(client, 'cat /proc/cmdline', seconds=15)
+    output_of_cmdline = executor(client, 'cat /proc/cmdline')
     assert (extra_args not in output_of_cmdline)
 
-    extra_cmdline = executor(client, 'sudo ros config get rancher.environment.EXTRA_CMDLINE', seconds=20)
+    extra_cmdline = executor(client, 'sudo ros config get rancher.environment.EXTRA_CMDLINE')
     assert ('/init {extra_args}'.format(extra_args=extra_args) in extra_cmdline)
 
-    rancher_password = executor(client, 'sudo ros config get rancher.password', seconds=15)
+    rancher_password = executor(client, 'sudo ros config get rancher.password')
     assert ('\n' == rancher_password)
 
-    config_password = executor(client, 'sudo ros config export | grep password', seconds=20)
+    config_password = executor(client, 'sudo ros config export | grep password')
     assert ('EXTRA_CMDLINE: /init cc.hostname=nope rancher.password=three' in config_password)
 
     test_yml = "echo -e 'test:\n  image: alpine\n  command: \"echo tell me a secret ${EXTRA_CMDLINE}\"\n  labels:\n    io.rancher.os.scope: system\n  environment:\n  - EXTRA_CMDLINE\n'> test.yml"
 
-    executor(client, test_yml, seconds=20)
+    executor(client, test_yml)
 
-    executor(client, 'sudo mv test.yml /var/lib/rancher/conf/test.yml', seconds=20)
-    executor(client, 'sudo ros service enable /var/lib/rancher/conf/test.yml', seconds=30)
-    executor(client, 'sudo ros service up test', seconds=20)
+    executor(client, 'sudo mv test.yml /var/lib/rancher/conf/test.yml')
+    executor(client, 'sudo ros service enable /var/lib/rancher/conf/test.yml')
+    executor(client, 'sudo ros service up test')
     test_content = 'test_1 | tell me a secret /init cc.hostname=nope rancher.password=three\n'
-    output_test = executor(client, 'sudo ros service logs test | grep secret', seconds=20)
+    output_test = executor(client, 'sudo ros service logs test | grep secret')
     assert (test_content.replace('\n', '') in output_test)

--- a/engine/test_dhcp_hostname.py
+++ b/engine/test_dhcp_hostname.py
@@ -3,16 +3,19 @@
 # Author :Bowen Lee
 
 
-def test_dhcp_hostname(ros_kvm_with_paramiko, cloud_config_url):
+def test_dhcp_hostname(ros_kvm_init, cloud_config_url):
     command = 'hostname'
     feed_back = 'rancher'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_dncp_hostname.yml'.format(url=cloud_config_url))
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    kwargs = dict(cloud_config='{url}test_dncp_hostname.yml'.format(url=cloud_config_url),
+                  is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     assert (feed_back in output)
 
     command_etc = 'cat /etc/hosts'
-    stdin, stdout, stderr = client.exec_command(command_etc, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_etc, timeout=60)
     output_etc = stdout.read().decode('utf-8')
     client.close()
     assert (output_etc in output_etc)

--- a/engine/test_environment.py
+++ b/engine/test_environment.py
@@ -3,23 +3,25 @@
 # Author :Bowen Lee
 
 
-def test_environment(ros_kvm_with_paramiko, cloud_config_url):
+def test_environment(ros_kvm_init, cloud_config_url):
     command = 'sudo system-docker inspect env | grep A=A'
     feed_back = 'A=A'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_environment.yml'.format(url=cloud_config_url))
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    tuple_return = ros_kvm_init(cloud_config='{url}test_environment.yml'.format(url=cloud_config_url),
+                                is_install_to_hard_drive=True)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     assert (feed_back in output)
 
     command_b = 'sudo system-docker inspect env | grep BB=BB'
     feed_back_b = 'BB=BB'
-    stdin, stdout, stderr = client.exec_command(command_b, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_b, timeout=60)
     output_b = stdout.read().decode('utf-8')
     assert (feed_back_b in output_b)
 
     command_c = 'sudo system-docker inspect env | grep BC=BC'
     feed_back_c = 'BC=BC'
-    stdin, stdout, stderr = client.exec_command(command_c, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_c, timeout=60)
     output_c = stdout.read().decode('utf-8')
     client.close()
     assert (feed_back_c in output_c)

--- a/engine/test_hostname.py
+++ b/engine/test_hostname.py
@@ -3,17 +3,19 @@
 # Author :Bowen Lee
 
 
-def test_hostname(ros_kvm_with_paramiko, cloud_config_url):
+def test_hostname(ros_kvm_init, cloud_config_url):
     command = 'hostname'
     feed_back = 'rancher-test'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_hostname.yml'.format(url=cloud_config_url))
+    kwargs = dict(is_install_to_hard_drive=True, cloud_config='{url}test_hostname.yml'.format(url=cloud_config_url))
+    tuple_return = ros_kvm_init(**kwargs)
 
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     assert (feed_back in output)
 
     command_etc = 'cat /etc/hosts'
-    stdin, stdout, stderr = client.exec_command(command_etc, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_etc, timeout=60)
     output_command = stdout.read().decode('utf-8')
     client.close()
     assert (feed_back in output_command)

--- a/engine/test_http_proxy.py
+++ b/engine/test_http_proxy.py
@@ -3,14 +3,15 @@
 # Author :Bowen Lee
 
 
-def test_http_proxy(ros_kvm_with_paramiko, cloud_config_url):
+def test_http_proxy(ros_kvm_init, cloud_config_url):
     command = 'sudo system-docker inspect docker'
     config_http = 'HTTP_PROXY=invalid'
     config_https = 'HTTPS_PROXY=invalid'
     config_no_proxy = 'NO_PROXY=invalid'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_http_proxy.yml'.format(url=cloud_config_url))
-
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    kwargs = dict(cloud_config='{url}test_http_proxy.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     client.close()
     assert ((config_http in output)

--- a/engine/test_kernel_headers.py
+++ b/engine/test_kernel_headers.py
@@ -3,11 +3,13 @@
 # Author :Bowen Lee
 
 
-def test_kernel_headers(ros_kvm_with_paramiko, cloud_config_url):
+def test_kernel_headers(ros_kvm_init, cloud_config_url):
     command = 'sudo system-docker inspect kernel-headers'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_kernel_headers.yml'.format(url=cloud_config_url))
-
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    kwargs = dict(cloud_config='{url}test_kernel_headers.yml'.format(url=cloud_config_url),
+                  is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     client.close()
     assert ('kernel-headers' in output)

--- a/engine/test_lenient_service_parsing.py
+++ b/engine/test_lenient_service_parsing.py
@@ -3,10 +3,13 @@
 # Author :Bowen Lee
 
 
-def test_lenient_service_parsing(ros_kvm_with_paramiko, cloud_config_url):
+def test_lenient_service_parsing(ros_kvm_init, cloud_config_url):
     command = 'sudo system-docker ps -a | grep test-parsing'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_lenient_service_parsing.yml'.format(url=cloud_config_url))
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    kwargs = dict(cloud_config='{url}test_lenient_service_parsing.yml'.format(url=cloud_config_url),
+                  is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     client.close()
     assert ('test-parsing' in output)

--- a/engine/test_misc.py
+++ b/engine/test_misc.py
@@ -4,16 +4,18 @@
 import time
 
 
-def test_misc(ros_kvm_with_paramiko, cloud_config_url):
+def test_misc(ros_kvm_init, cloud_config_url):
     command = "sudo ros env printenv FLANNEL_NETWORK"
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_misc.yml'.format(url=cloud_config_url))
-
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    kwargs = dict(cloud_config='{url}test_misc.yml'.format(url=cloud_config_url),
+                  is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     assert ('10.244.0.0/16' in output)
 
     command_dncp = "ps -ef"
-    stdin, stdout, stderr = client.exec_command(command_dncp, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_dncp, timeout=60)
     output_dncp = stdout.read().decode('utf-8')
 
     assert ('dhcpcd -M' in output_dncp)
@@ -23,16 +25,16 @@ def test_misc(ros_kvm_with_paramiko, cloud_config_url):
                   "&& sudo ros tls gen" \
                   "&& sudo ros c set rancher.docker.tls true" \
                   "&& sudo system-docker restart docker"
-    client.exec_command(command_tls, timeout=20)
+    client.exec_command(command_tls, timeout=60)
     time.sleep(10)
     command_check_docker = 'docker --tlsverify version'
-    stdin, stdout, stderr = client.exec_command(command_check_docker, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_check_docker, timeout=60)
     output_docker_info = stdout.read().decode('utf-8')
     assert (('Client' in output_docker_info)
             and ('Server' in output_docker_info))
 
     stdin, stdout, stderr = client.exec_command('set -e -x &&'
-                                                'pidof system-dockerd', timeout=10)
+                                                'pidof system-dockerd', timeout=60)
 
     assert ('1' in stdout.read().decode('utf-8'))
     client.close()

--- a/engine/test_modules.py
+++ b/engine/test_modules.py
@@ -2,11 +2,24 @@
 # Create date: 2018-10-29
 # Author :Bowen Lee
 
+from utils.connect_to_os import connection, executor
 
-def test_modules(ros_kvm_for_kernel_parameters):
-    command = 'lsmod'
-    client = ros_kvm_for_kernel_parameters(kernel_parameters='rancher.modules=[btrfs]')
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
-    output = stdout.read().decode('utf-8')
-    client.close()
+
+def test_modules(ros_kvm_init):
+    command = 'lsmod | grep btrfs'
+    kwargs = dict(is_kernel_parameters=True,
+                  kernel_parameters='rancher.state.dev=LABEL=RANCHER_STATE rancher.modules=[btrfs] rancher.state.autoformat=[/dev/sda,/dev/vda]')
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    output = executor(client, command)
+    assert ('btrfs' in output)
+
+
+def test_cloud_config_modules(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}test_cloud_config_modules.yml'.format(url=cloud_config_url),
+                  is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+
+    output = executor(client, 'lsmod | grep btrfs')
     assert ('btrfs' in output)

--- a/engine/test_mounts.py
+++ b/engine/test_mounts.py
@@ -5,18 +5,21 @@
 import time
 
 
-def test_mounts(ros_kvm_with_paramiko, cloud_config_url):
+def test_mounts(ros_kvm_init, cloud_config_url):
     command = 'cat /home/rancher/test | grep test'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_mounts.yml'.format(url=cloud_config_url))
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    kwargs = dict(cloud_config='{url}test_mounts.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True,
+                  is_second_hd=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     assert ('test' in output)
 
     command_mk = 'sudo mkfs.ext4 /dev/vdb && sudo cloud-init-execute'
-    client.exec_command(command_mk, timeout=20)
+    client.exec_command(command_mk, timeout=60)
     # Network delay
     time.sleep(5)
-    stdin, stdout, stderr = client.exec_command('mount', timeout=10)
+    stdin, stdout, stderr = client.exec_command('mount', timeout=60)
     output = stdout.read().decode('utf-8')
     client.close()
     assert ('/home/rancher/a' in output

--- a/engine/test_oem.py
+++ b/engine/test_oem.py
@@ -4,8 +4,12 @@
 from utils.connect_to_os import executor, connection
 
 
-def test_oem(ros_kvm_return_ip, cloud_config_url):
-    client, ip = ros_kvm_return_ip(cloud_config='{url}/default.yml'.format(url=cloud_config_url))
+def test_oem(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True,
+                  is_second_hd=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    ip = tuple_return[1]
     c_add_ome_config = 'set -x && ' \
                        'set -e && ' \
                        'sudo mkfs.ext4 -L RANCHER_OEM /dev/vdb && ' \
@@ -17,7 +21,7 @@ def test_oem(ros_kvm_return_ip, cloud_config_url):
 
     executor(client, 'sudo reboot')
 
-    second_client = connection(ip)
+    second_client = connection(ip, None)
     c_ls_oem = 'ls /usr/share/ros/oem'
     output_ls_oem = executor(second_client, c_ls_oem)
     assert ('oem-config.yml' in output_ls_oem)

--- a/engine/test_preload.py
+++ b/engine/test_preload.py
@@ -2,37 +2,36 @@
 # Create date: 2018-11-19
 # Author :Bowen Lee
 
-# coding = utf-8
-# Create date: 2018-11-19
-# Author :Bowen Lee
-
 from utils.connect_to_os import connection, executor
 
 
-def test_preload(ros_kvm_return_ip, cloud_config_url):
-    client, ip = ros_kvm_return_ip(cloud_config='{url}/default.yml'.format(url=cloud_config_url))
+def test_preload(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    ip = tuple_return[1]
     c_com_img = 'wait-for-docker \
                         && docker pull busybox \
                         && sudo docker save -o /var/lib/rancher/preload/system-docker/busybox.tar busybox \
                         && sudo gzip /var/lib/rancher/preload/system-docker/busybox.tar \
                         && sudo system-docker pull alpine \
                         && sudo system-docker save -o /var/lib/rancher/preload/docker/alpine.tar alpine'
-    executor(client, c_com_img, seconds=50)
+    executor(client, c_com_img)
 
-    c_ls_sys_docker_img = 'test -f /var/lib/rancher/preload/system-docker/busybox.tar.gz && ' \
+    c_ls_sys_docker_img = 'test -f /var/lib/rancher/preload/system-docker/busybox.tar.gz ; ' \
                           'echo $?'
-    output_sys_docker = executor(client, c_ls_sys_docker_img, seconds=10).replace('\n', '')
+    output_sys_docker = executor(client, c_ls_sys_docker_img).replace('\n', '')
     assert ('0' == output_sys_docker)
 
-    c_ls_user_docker_img = 'test -f /var/lib/rancher/preload/docker/alpine.tar && ' \
+    c_ls_user_docker_img = 'test -f /var/lib/rancher/preload/docker/alpine.tar ; ' \
                            'echo $?'
-    output_user_docker = executor(client, c_ls_user_docker_img, seconds=10).replace('\n', '')
+    output_user_docker = executor(client, c_ls_user_docker_img).replace('\n', '')
     assert ('0' == output_user_docker)
 
     executor(client, 'sudo reboot')
-    second_client = connection(ip)
+    second_client = connection(ip, seconds=30)
 
-    output_sys_docker = executor(second_client, 'sudo system-docker images | grep busybox', seconds=10)
+    output_sys_docker = executor(second_client, 'sudo system-docker images | grep busybox')
     assert ('busybox' in output_sys_docker)
-    output_user_docker = executor(second_client, 'docker images | grep alpine', seconds=10)
+    output_user_docker = executor(second_client, 'docker images | grep alpine')
     assert ('alpine' in output_user_docker)

--- a/engine/test_ros_config.py
+++ b/engine/test_ros_config.py
@@ -3,44 +3,46 @@
 # Author :Hailong
 
 
-def test_ros_config(ros_kvm_with_paramiko, cloud_config_url):
+def test_ros_config(ros_kvm_init, cloud_config_url):
     fb_cc_hostname = 'hostname3'
     command_cc_hostname = 'sudo ros config get hostname'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_ros_config.yml'.format(url=cloud_config_url))
-    stdin, stdout, stderr = client.exec_command(command_cc_hostname, timeout=10)
+    kwargs = dict(cloud_config='{url}test_ros_config.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command_cc_hostname, timeout=60)
     output_cc_hostname = stdout.read().decode('utf-8').replace('\n', '')
     assert (fb_cc_hostname == output_cc_hostname)
 
     # Customize hostname and verify
     fb_cli_hostname = 'rancher-test'
     command_cli_hostname = 'sudo ros config set hostname {}'.format(fb_cli_hostname)
-    stdin, stdout, stderr = client.exec_command(command_cli_hostname + '&&' + command_cc_hostname, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_cli_hostname + '&&' + command_cc_hostname, timeout=60)
     output_cli_hostname = stdout.read().decode('utf-8').replace('\n', '')
     assert (fb_cli_hostname == output_cli_hostname)
 
     # Verify that rancher.log
     fb_cc_log = 'true'
     command_cc_log = 'sudo ros config get rancher.log'
-    stdin, stdout, stderr = client.exec_command(command_cc_log, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_cc_log, timeout=60)
     output_cc_log = stdout.read().decode('utf-8').replace('\n', '')
     assert (fb_cc_log == output_cc_log)
 
     fb_cli_log = 'false'
     command_cli_log = 'sudo ros config set rancher.log {}'.format(fb_cli_log)
-    stdin, stdout, stderr = client.exec_command(command_cli_log + '&&' + command_cc_log, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_cli_log + '&&' + command_cc_log, timeout=60)
     output_cli_log = stdout.read().decode('utf-8').replace('\n', '')
     assert (fb_cli_log == output_cli_log)
 
     # Verify that rancher.debug
     fb_cc_debug = 'false'
     command_cc_debug = 'sudo ros config get rancher.debug'
-    stdin, stdout, stderr = client.exec_command(command_cc_debug, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_cc_debug, timeout=60)
     output_cc_debug = stdout.read().decode('utf-8').replace('\n', '')
     assert (fb_cc_debug == output_cc_debug)
 
     fb_cli_debug = 'true'
     command_cli_debug = 'sudo ros config set rancher.debug {}'.format(fb_cli_debug)
-    stdin, stdout, stderr = client.exec_command(command_cli_debug + '&&' + command_cc_debug, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_cli_debug + '&&' + command_cc_debug, timeout=60)
     output_cli_debug = stdout.read().decode('utf-8').replace('\n', '')
     assert (fb_cli_debug == output_cli_debug)
 
@@ -48,13 +50,13 @@ def test_ros_config(ros_kvm_with_paramiko, cloud_config_url):
     fb_cli_dns = '- a\n- b'
     command_cli_set_dns = 'sudo ros config set rancher.network.dns.search "[a,b]"'
     command_cli_get_dns = 'sudo ros config get rancher.network.dns.search'
-    stdin, stdout, stderr = client.exec_command(command_cli_set_dns + '&&' + command_cli_get_dns, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_cli_set_dns + '&&' + command_cli_get_dns, timeout=60)
     output_cli_dns = stdout.read().decode('utf-8')
     assert (fb_cli_dns in output_cli_dns)
 
     fb_cli_dns_empty = '[]'
     command_cli_set_dns_empty = 'sudo ros config set rancher.network.dns.search "{}"'.format(fb_cli_dns_empty)
-    stdin, stdout, stderr = client.exec_command(command_cli_set_dns_empty + '&&' + command_cli_get_dns, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_cli_set_dns_empty + '&&' + command_cli_get_dns, timeout=60)
     output_cli_dns_empty = stdout.read().decode('utf-8').replace('\n', '')
     assert (fb_cli_dns_empty == output_cli_dns_empty)
 
@@ -88,27 +90,27 @@ def test_ros_config(ros_kvm_with_paramiko, cloud_config_url):
 
 def _get_export(client):
     command = 'sudo ros config export'
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     return output
 
 
 def _get_private_export(client):
     command = 'sudo ros config export --private'
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     return output
 
 
 def _get_full_export(client):
     command = 'sudo ros config export --full'
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     return output
 
 
 def _get_private_and_full_export(client):
     command = 'sudo ros config export --private --full'
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     return output

--- a/engine/test_ros_service.py
+++ b/engine/test_ros_service.py
@@ -2,46 +2,48 @@
 # Create date: 2018-11-15
 # Author :Bowen Lee
 
-from utils.connect_to_os import executor
+from utils.connect_to_os import executor, connection
 
 
-def test_ros_local_service(ros_kvm_with_paramiko, cloud_config_url):
-    client = ros_kvm_with_paramiko(cloud_config=
-                                   '{url}/default.yml'.format(url=cloud_config_url))
+def test_ros_local_service(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
 
     create_test_image = 'echo "FROM $(sudo system-docker images --format '"{{.Repository}}:{{.Tag}}"' | grep os-base)" > Dockerfile'
     build_test_image = 'sudo system-docker build -t test_image .'
-    executor(client, create_test_image, seconds=10)
-    executor(client, build_test_image, seconds=15)
+    executor(client, create_test_image)
+    executor(client, build_test_image)
     add_contents = 'echo "test:" > test.yml && echo "  image: test_image" >> test.yml ' \
                    '&& echo "  entrypoint: ls" >> test.yml && echo "  labels:" >> test.yml ' \
                    '&& echo "    io.rancher.os.scope: system" >> test.yml ' \
                    '&& echo "    io.rancher.os.after: console" >> test.yml'
 
-    executor(client, add_contents, seconds=10)
+    executor(client, add_contents)
 
-    executor(client, 'sudo cp test.yml /var/lib/rancher/conf/test.yml', seconds=20)
-    executor(client, 'sudo ros service enable /var/lib/rancher/conf/test.yml', seconds=20)
-    executor(client, 'sudo ros service up test', seconds=30)
-    output = executor(client, 'sudo ros service logs test | grep bin', seconds=20)
+    executor(client, 'sudo cp test.yml /var/lib/rancher/conf/test.yml')
+    executor(client, 'sudo ros service enable /var/lib/rancher/conf/test.yml')
+    executor(client, 'sudo ros service up test')
+    output = executor(client, 'sudo ros service logs test | grep bin')
     assert ('bin' in output)
 
 
-def test_ros_local_service_user(ros_kvm_with_paramiko, cloud_config_url):
-    client = ros_kvm_with_paramiko(cloud_config=
-                                   '{url}/default.yml'.format(url=cloud_config_url))
+def test_ros_local_service_user(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
     create_test_image = 'echo "FROM alpine" > Dockerfile'
-    executor(client, create_test_image, seconds=10)
+    executor(client, create_test_image)
     build_test_image = 'sudo docker build -t test_image_user .'
-    executor(client, build_test_image, seconds=40)
+    executor(client, build_test_image)
     add_contents = 'echo "test:" > test.yml && echo "  image: test_image_user" >> test.yml ' \
                    '&& echo "  entrypoint: ls" >> test.yml && echo "  labels:" >> test.yml ' \
                    '&& echo "    io.rancher.os.scope: user" >> test.yml ' \
                    '&& echo "    io.rancher.os.after: console" >> test.yml'
 
-    executor(client, add_contents, seconds=20)
-    executor(client, 'sudo cp test.yml /var/lib/rancher/conf/test.yml', seconds=20)
-    executor(client, 'sudo ros service enable /var/lib/rancher/conf/test.yml', seconds=20)
-    executor(client, 'sudo ros service up test', seconds=30)
-    output = executor(client, 'sudo ros service logs test | grep bin', seconds=20)
+    executor(client, add_contents)
+    executor(client, 'sudo cp test.yml /var/lib/rancher/conf/test.yml')
+    executor(client, 'sudo ros service enable /var/lib/rancher/conf/test.yml')
+    executor(client, 'sudo ros service up test')
+    output = executor(client, 'sudo ros service logs test | grep bin')
     assert ('bin' in output)

--- a/engine/test_shared_mount.py
+++ b/engine/test_shared_mount.py
@@ -3,7 +3,7 @@
 # Author :Hailong
 
 
-def test_shared_mount(ros_kvm_with_paramiko, cloud_config_url):
+def test_shared_mount(ros_kvm_init, cloud_config_url):
     command = 'sudo mkdir /mnt/shared &&  \
                sudo touch /test &&  \
                sudo system-docker run  \
@@ -13,9 +13,11 @@ def test_shared_mount(ros_kvm_with_paramiko, cloud_config_url):
                    mount --bind / /mnt/shared &&  \
                ls /mnt/shared'
     feed_back = 'test'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/default.yml'.format(url=cloud_config_url))
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
 
-    stdin, stdout, stderr = client.exec_command(command, timeout=20)
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     client.close()
     assert (feed_back in output)

--- a/engine/test_ssh_key_merge.py
+++ b/engine/test_ssh_key_merge.py
@@ -6,8 +6,10 @@ import time
 from utils.connect_to_os import executor, connection
 
 
-def test_ssh_key_merge(ros_kvm_with_paramiko, cloud_config_url):
-    client = ros_kvm_with_paramiko(cloud_config='{url}/default.yml'.format(url=cloud_config_url))
+def test_ssh_key_merge(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
 
     set_metadata = 'echo -e ' \
                    '"SSHPublicKeys: \n "0": zero \n "1": one\n "2": two"  ' \
@@ -19,10 +21,10 @@ def test_ssh_key_merge(ros_kvm_with_paramiko, cloud_config_url):
 
     set_current = 'sudo ros config get ssh_authorized_keys > current_config'
 
-    executor(client, 'sudo rm /var/lib/rancher/conf/cloud-config.yml', seconds=5)
-    executor(client, 'sudo chmod -R 777 /var/lib/rancher/conf/', seconds=5)
-    executor(client, set_metadata, seconds=10)
-    executor(client, set_ssh_aut_key, seconds=10)
-    executor(client, set_current, seconds=10)
-    output = executor(client, 'diff expected current_config && echo $?', seconds=10).replace('\n', '')
+    executor(client, 'sudo rm /var/lib/rancher/conf/cloud-config.yml')
+    executor(client, 'sudo chmod -R 777 /var/lib/rancher/conf/')
+    executor(client, set_metadata)
+    executor(client, set_ssh_aut_key)
+    executor(client, set_current)
+    output = executor(client, 'diff expected current_config && echo $?').replace('\n', '')
     assert (output == '0')

--- a/engine/test_start_commands.py
+++ b/engine/test_start_commands.py
@@ -3,11 +3,15 @@
 # Author :Hailong
 
 
-def test_start_commands(ros_kvm_with_paramiko, cloud_config_url):
+def test_start_commands(ros_kvm_init, cloud_config_url):
     command = 'ls /home/rancher | grep "test[0-5]"  | wc -l'
     feed_back = '5'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_start_commands.yml'.format(url=cloud_config_url))
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+
+    kwargs = dict(cloud_config='{url}test_start_commands.yml'.format(url=cloud_config_url),
+                  is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     assert (feed_back in output)
 

--- a/engine/test_subdir.py
+++ b/engine/test_subdir.py
@@ -3,14 +3,16 @@
 # Author :Hailong
 
 
-def test_subdir(ros_kvm_for_kernel_parameters):
+def test_subdir(ros_kvm_init):
     command = 'mkdir x &&  \
               sudo mount $(sudo ros dev LABEL=RANCHER_STATE) x &&  \
               test -d x/ros_subdir/home/rancher;  \
               echo $?'
     feed_back = '0'
-    client = ros_kvm_for_kernel_parameters(kernel_parameters='rancher.state.directory=ros_subdir')
-
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    kwargs = dict(is_kernel_parameters=True,
+                  kernel_parameters='rancher.state.directory=ros_subdir rancher.state.dev=LABEL=RANCHER_STATE rancher.state.autoformat=[/dev/sda,/dev/vda]')
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8').replace('\n', '')
     assert (feed_back == output)

--- a/engine/test_swap.py
+++ b/engine/test_swap.py
@@ -5,12 +5,16 @@
 import time
 
 
-def test_swap(ros_kvm_with_paramiko, cloud_config_url):
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_swap.yml'.format(url=cloud_config_url))
-    client.exec_command('sudo mkswap /dev/vdb && sudo cloud-init-execute', timeout=10)
+def test_swap(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}test_swap.yml'.format(url=cloud_config_url), is_second_hd=True,
+                  is_install_to_hard_drive=True)
+
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    client.exec_command('sudo mkswap /dev/vdb && sudo cloud-init-execute', timeout=60)
     # Network delay
     time.sleep(5)
-    stdin, stdout, stderr = client.exec_command('cat /proc/swaps | grep /dev/vdb', timeout=10)
+    stdin, stdout, stderr = client.exec_command('cat /proc/swaps | grep /dev/vdb', timeout=60)
     output = stdout.read().decode('utf-8')
     client.close()
     assert ('/dev/vdb' in output)

--- a/engine/test_switch_console.py
+++ b/engine/test_switch_console.py
@@ -5,9 +5,11 @@
 from utils.connect_to_os import executor, connection
 
 
-def test_switch_console(ros_kvm_return_ip, cloud_config_url):
-    client, ip = ros_kvm_return_ip(cloud_config=
-                                   '{url}/default.yml'.format(url=cloud_config_url))
+def test_switch_console(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    ip = tuple_return[1]
     output = executor(client, 'sudo ros console list')
     list_of_console = output.split('\n')
 
@@ -24,12 +26,12 @@ def test_switch_console(ros_kvm_return_ip, cloud_config_url):
             list_console_v.append(console_v.split(' ')[1])
 
     for console_v in list_console_v:
-        client = connection(ip)
+        client = connection(ip, None)
 
         executor(client, 'sudo ros console switch -f {console_version}'.format(console_version=console_v))
 
-        client = connection(ip)
-        version = executor(client, 'sudo ros console list |grep current', seconds=20)
+        client = connection(ip, None)
+        version = executor(client, 'sudo ros console list |grep current')
 
         assert (console_v in version)
 

--- a/engine/test_switch_docker.py
+++ b/engine/test_switch_docker.py
@@ -6,9 +6,10 @@ import time
 from utils.connect_to_os import executor, connection
 
 
-def test_switch_docker(ros_kvm_with_paramiko, cloud_config_url):
-    client = ros_kvm_with_paramiko(cloud_config=
-                                   '{url}/default.yml'.format(url=cloud_config_url))
+def test_switch_docker(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
     output = executor(client, 'sudo ros engine list')
     list_of_docker = output.split('\n')
     list_of_docker.pop(-1)
@@ -31,12 +32,12 @@ def test_switch_docker(ros_kvm_with_paramiko, cloud_config_url):
 
     list_of_checking_docker_v = list_docker_v[:5] + [special_version, special2_version, special3_version]
 
-    executor(client, 'sudo ros config set rancher.docker.storage_driver overlay2', seconds=10)
+    executor(client, 'sudo ros config set rancher.docker.storage_driver overlay2')
 
     for docker_v in list_of_checking_docker_v:
         executor(client, 'sudo ros engine switch {docker_version}'.format(docker_version=docker_v))
         time.sleep(20)
-        version = executor(client, 'sudo docker -v', seconds=10)
+        version = executor(client, 'sudo docker -v', seconds=20)
         assert (docker_v.replace('docker-', '') in version)
 
         executor(client, 'sudo ros engine switch {docker_version}'.format(docker_version=current_version))

--- a/engine/test_sysctl.py
+++ b/engine/test_sysctl.py
@@ -3,17 +3,19 @@
 # Author :Hailong
 
 
-def test_sysctl(ros_kvm_with_paramiko, cloud_config_url):
+def test_sysctl(ros_kvm_init, cloud_config_url):
     command = 'sudo cat /proc/sys/kernel/domainname'
     feed_back = 'test'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_sysctl.yml'.format(url=cloud_config_url))
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    kwargs = dict(cloud_config='{url}test_sysctl.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8').replace('\n', '')
     assert (feed_back == output)
 
     command_b = 'sudo cat /proc/sys/dev/cdrom/debug'
     feed_back_b = '1'
-    stdin, stdout, stderr = client.exec_command(command_b, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_b, timeout=60)
     output_b = stdout.read().decode('utf-8').replace('\n', '')
     client.close()
     assert (feed_back_b == output_b)

--- a/engine/test_tls.py
+++ b/engine/test_tls.py
@@ -4,11 +4,13 @@
 # Editor:Bowen Lee
 
 
-def test_tls(ros_kvm_with_paramiko, cloud_config_url):
+def test_tls(ros_kvm_init, cloud_config_url):
     command = 'set -e -x && sudo ros tls gen && docker --tlsverify version'
     feed_back = 'Client'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_tls.yml'.format(url=cloud_config_url))
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    kwargs = dict(cloud_config='{url}/test_tls.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     # Must be save in local constant
     output_content = stdout.read().decode('utf-8')
     client.close()

--- a/engine/test_upgrade.py
+++ b/engine/test_upgrade.py
@@ -5,8 +5,11 @@
 from utils.connect_to_os import connection, executor
 
 
-def test_upgrade(ros_kvm_return_ip, cloud_config_url):
-    client, ip = ros_kvm_return_ip(cloud_config='{url}/default.yml'.format(url=cloud_config_url))
+def test_upgrade(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    ip = tuple_return[1]
     output = executor(client, 'sudo ros os list')
     list_of_os = output.split('\n')
     current_version = None
@@ -26,11 +29,13 @@ def test_upgrade(ros_kvm_return_ip, cloud_config_url):
     list_ros_check = list_ros_v[:3]
 
     for ros_v in list_ros_check:
-        client = connection(ip)
+        client = connection(ip, None)
 
         executor(client, 'sudo ros os upgrade -f -i {os_version}'.format(os_version=ros_v))
 
-        client = connection(ip)
-        output = executor(client, "sudo ros -v | awk  '{print $2}'").replace('\n', '')
+        client = connection(ip, None)
+        output = executor(client, "sudo ros -v | awk  '{print $2}'")
+        if output:
+            output = output.replace('\n', '')
         assert (output in ros_v)
         executor(client, 'sudo ros os upgrade -f -i {os_version}'.format(os_version=current_version))

--- a/engine/test_write_files.py
+++ b/engine/test_write_files.py
@@ -3,31 +3,33 @@
 # Author :Hailong
 
 
-def test_write_files(ros_kvm_with_paramiko, cloud_config_url):
+def test_write_files(ros_kvm_init, cloud_config_url):
     command = 'sudo cat /test'
     feed_back = 'console content'
-    client = ros_kvm_with_paramiko(cloud_config='{url}/test_write_files.yml'.format(url=cloud_config_url))
+    kwargs = dict(cloud_config='{url}test_write_files.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
 
-    stdin, stdout, stderr = client.exec_command(command, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command, timeout=60)
     output = stdout.read().decode('utf-8')
     assert (feed_back in output)
 
     command_b = 'sudo cat /test2'
     feed_back_b = 'console content'
 
-    stdin, stdout, stderr = client.exec_command(command_b, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_b, timeout=60)
     output_b = stdout.read().decode('utf-8')
     assert (feed_back_b in output_b)
 
     command_c = 'sudo system-docker exec ntp cat /test'
     feed_back_c = 'ntp content'
-    stdin, stdout, stderr = client.exec_command(command_c, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_c, timeout=60)
     output_c = stdout.read().decode('utf-8')
     assert (feed_back_c in output_c)
 
     command_d = 'sudo system-docker exec syslog cat /test'
     feed_back_d = 'syslog content'
-    stdin, stdout, stderr = client.exec_command(command_d, timeout=10)
+    stdin, stdout, stderr = client.exec_command(command_d, timeout=60)
     output_d = stdout.read().decode('utf-8')
     client.close()
     assert (feed_back_d in output_d)

--- a/executor.py
+++ b/executor.py
@@ -14,7 +14,6 @@ if __name__ == '__main__':
     try:
         pytest.main(
             ["-s",
-             BASE_DIR + '{script_package}'.format(script_package='/project_path/engine/'),
-             '--cloud_config_url={url}'.format(url='http://192.168.1.24/ros')])
+             BASE_DIR + '{script_package}'.format(script_package='/code/engine/test_preload.py')])
     except Exception as e:
         print(e.args[0])

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skip_missing_interpreters = True
 passenv = *
 description = Run the pytest with current enviroment
 deps = -r  requirements.txt
-commands = py.test -n 8 -v --duration=10 engine/ --junitxml=osTestsJunit.xml
+commands = py.test -n 5 -v --duration=10 engine/ --junitxml=osTestsJunit.xml
 
 [testenv:pep8]
 passenv = CI TRAVIS TRAVIS_*

--- a/utils/connect_to_os.py
+++ b/utils/connect_to_os.py
@@ -8,26 +8,33 @@ import time
 
 import paramiko
 
+SSH_KEY_PATH = '/opt/os-tests/assets/id_rsa'
 
-def connection(ip):
-    for _ in range(30):
-        time.sleep(10)
+
+def connection(ip, seconds):
+    for _ in range(40):
+        if seconds:
+            time.sleep(seconds)
+        else:
+            time.sleep(10)
         try:
             ssh = paramiko.SSHClient()
+            private_key = paramiko.RSAKey.from_private_key_file(SSH_KEY_PATH)
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
             ssh.connect(hostname=ip,
                         username='rancher',
-                        password='')
+                        password='',
+                        pkey=private_key)
+            # The issue can solve 'SSH session not active'  https://github.com/paramiko/paramiko/issues/928
             if ssh.get_transport().active:
                 break
         except:
             ssh.close()
-
     return ssh
 
 
-def executor(client, command, seconds=40):
+def executor(client, command, seconds=100):
     assert (client and command is not None)
     stdin, stdout, stderr = client.exec_command(command, timeout=seconds)
     output = stdout.read().decode('utf-8')


### PR DESCRIPTION
```
ksd@hailong-ranchervm-2:~$ tmux a -t ros_test

202.31s call     engine/test_cloud_config_console.py::test_cloud_config_console
201.65s call     engine/test_cloud_init.py::test_cloud_init
186.34s call     engine/test_cmdline.py::test_cmdline
176.13s call     engine/test_misc.py::test_misc
======================================================= 34 passed in 1575.62 seconds ========================================================
pep8 installed: certifi==2018.10.15,chardet==3.0.4,codecov==2.0.15,coverage==4.5.2,filelock==3.0.10,flake8==3.5.0,idna==2.7,mccabe==0.6.1,pluggy==0.8.0,py==1.7.0,pycodestyle==2.3.1,pyflakes==1.6.0,requests==2.20.1,six==1.11.0,toml==0.10.0,tox==3.5.2,urllib3==1.24.1,virtualenv==16.1.0
pep8 run-test-pre: PYTHONHASHSEED='2202672578'
pep8 runtests: commands[0] | flake8 os_test


__________________________________________________________________ summary __________________________________________________________________
  py35: commands succeeded
  pep8: commands succeeded
  cover: commands succeeded
  congratulations :)```