### PR TITLE
Add the new test cases named test bad state, test nonexistent state, test network.

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,1 +1,1 @@
-from engine.test_hostname import *
+

--- a/engine/conftest.py
+++ b/engine/conftest.py
@@ -55,6 +55,7 @@ KVM_XML = '''<domain type='kvm'>
         <source bridge='virbr0'/>
         <mac address="{mac_address}"/>
         </interface>
+        {network_xml_gist}
         <input type='mouse' bus='ps2'/>
         <graphics type='vnc' port='-1' autoport='yes' listen='0.0.0.0' keymap='en-us'/>
         </devices>
@@ -66,6 +67,21 @@ SECOND_DRIVE_XML_GIST = '''
         <source file="/opt/os-tests/images/{second_drive_name}.qcow2"/>
         <target dev="vdb" bus="virtio"/>
         </disk>
+'''
+
+NETWORK_XML_GIST = '''
+        <interface type='bridge'>
+        <source bridge='virbr0'/>
+        </interface>
+        <interface type='bridge'>
+        <source bridge='virbr0'/>
+        </interface>
+        <interface type='bridge'>
+        <source bridge='virbr0'/>
+        </interface>
+        <interface type='bridge'>
+        <source bridge='virbr0'/>
+        </interface>      
 '''
 
 KERNEL_PARAMETERS_XML = '''<domain type='kvm'>
@@ -254,12 +270,10 @@ def ros_kvm_init():
         virtual_name = _id_generator()
 
         mac = _mac_generator()
-        # TODO It's not useful
         _manage_path()
 
         if kwargs.get('is_kernel_parameters'):
             kernel_parameters = kwargs.get('kernel_parameters')
-            # TODO KERNEL_PARAMETERS_XML
             xml_for_virtual = KERNEL_PARAMETERS_XML.format(
                 virtual_name=virtual_name,
                 mac_address=mac,
@@ -268,18 +282,22 @@ def ros_kvm_init():
         else:
             if kwargs.get('is_second_hd'):
                 second_drive_name = virtual_name + '_second'
-                xml_for_virtual = KVM_XML.format(virtual_name=virtual_name,
-                                                 mac_address=mac,
-                                                 v_name_for_source=virtual_name,
-                                                 second_driver_gist=SECOND_DRIVE_XML_GIST.format(
-                                                     second_drive_name=second_drive_name))
-                # TODO Create second_drive
+                #  Create second_drive
                 _create_qcow2('2', second_drive_name)
             else:
-                xml_for_virtual = KVM_XML.format(virtual_name=virtual_name,
-                                                 mac_address=mac,
-                                                 v_name_for_source=virtual_name,
-                                                 second_driver_gist='')
+                second_drive_name = ''
+
+            if kwargs.get('is_network_gist'):
+                network_xml_gist = NETWORK_XML_GIST
+
+            else:
+                network_xml_gist = ''
+
+            xml_for_virtual = KVM_XML.format(virtual_name=virtual_name,
+                                             mac_address=mac,
+                                             v_name_for_source=virtual_name,
+                                             second_driver_gist=second_drive_name,
+                                             network_xml_gist=network_xml_gist)
 
         # region    Create qcow2
         if kwargs.get('is_b2d'):

--- a/engine/test_bad_state.py
+++ b/engine/test_bad_state.py
@@ -1,0 +1,27 @@
+# coding = utf-8
+# Create date: 2018-11-29
+# Author :Hailong
+
+from utils.connect_to_os import executor
+
+
+def test_bad_state(ros_kvm_init):
+    kwargs = dict(
+        kernel_parameters='--no-format rancher.state.dev=LABEL=BAD_STATE rancher.state.autoformat=[/dev/sda,/dev/vda]',
+        is_kernel_parameters=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    output = executor(client, 'mount | grep /var/lib/docker')
+    client.close()
+    assert ('rootfs' in output)
+
+
+def test_bad_state_with_wait(ros_kvm_init):
+    kwargs = dict(
+        kernel_parameters='--no-format rancher.state.dev=LABEL=BAD_STATE rancher.state.wait rancher.state.autoformat=[/dev/sda,/dev/vda]',
+        is_kernel_parameters=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    outptu = executor(client, 'mount | grep /var/lib/docker')
+    client.close()
+    assert ('rootfs' in outptu)

--- a/engine/test_kernel_headers.py
+++ b/engine/test_kernel_headers.py
@@ -4,12 +4,12 @@
 
 
 def test_kernel_headers(ros_kvm_init, cloud_config_url):
-    command = 'sudo system-docker inspect kernel-headers'
+    command = 'sleep ; sudo system-docker inspect kernel-headers'
     kwargs = dict(cloud_config='{url}test_kernel_headers.yml'.format(url=cloud_config_url),
                   is_install_to_hard_drive=True)
     tuple_return = ros_kvm_init(**kwargs)
     client = tuple_return[0]
-    stdin, stdout, stderr = client.exec_command(command, timeout=60)
+    stdin, stdout, stderr = client.exec_command(command)
     output = stdout.read().decode('utf-8')
     client.close()
     assert ('kernel-headers' in output)

--- a/engine/test_kernel_headers.py
+++ b/engine/test_kernel_headers.py
@@ -4,7 +4,7 @@
 
 
 def test_kernel_headers(ros_kvm_init, cloud_config_url):
-    command = 'sleep ; sudo system-docker inspect kernel-headers'
+    command = 'sleep 10; sudo system-docker inspect kernel-headers'
     kwargs = dict(cloud_config='{url}test_kernel_headers.yml'.format(url=cloud_config_url),
                   is_install_to_hard_drive=True)
     tuple_return = ros_kvm_init(**kwargs)

--- a/engine/test_mounts.py
+++ b/engine/test_mounts.py
@@ -11,15 +11,15 @@ def test_mounts(ros_kvm_init, cloud_config_url):
                   is_second_hd=True)
     tuple_return = ros_kvm_init(**kwargs)
     client = tuple_return[0]
-    stdin, stdout, stderr = client.exec_command(command, timeout=60)
+    stdin, stdout, stderr = client.exec_command(command, timeout=100)
     output = stdout.read().decode('utf-8')
     assert ('test' in output)
 
-    command_mk = 'sudo mkfs.ext4 /dev/vdb && sudo cloud-init-execute'
-    client.exec_command(command_mk, timeout=60)
+    command_mk = 'sudo mkfs.ext4 /dev/vdb ; sudo cloud-init-execute'
+    client.exec_command(command_mk, timeout=100)
     # Network delay
-    time.sleep(5)
-    stdin, stdout, stderr = client.exec_command('mount', timeout=60)
+    time.sleep(20)
+    stdin, stdout, stderr = client.exec_command('mount', timeout=100)
     output = stdout.read().decode('utf-8')
     client.close()
     assert ('/home/rancher/a' in output

--- a/engine/test_network.py
+++ b/engine/test_network.py
@@ -1,0 +1,181 @@
+# coding = utf-8
+# Create date: 2018-11-28
+# Author :Hailong
+
+from utils.connect_to_os import executor
+
+data_source_url = 'https://gist.githubusercontent.com/kingsd041/310b5f0ab89567e93edadf1bbed822fb/' \
+                  'raw/1ef388e085ffb4b6bb352c8383aa4b7ad3dafd33/test_network_from_url.txt'
+
+
+def test_network_from_cloud_cfg(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}test_network_from_cloudcfg.yml'.format(url=cloud_config_url),
+                  is_install_to_hard_drive=True, is_network_gist=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    # Verify mtu
+    output_mtu = executor(client, 'ip address show bond0')
+    assert ('mtu 1450' in output_mtu)
+
+    # Verify vlan
+    output_eth1_100 = executor(client, 'ip address show eth1.100')
+    assert ('eth1.100@eth1' in output_eth1_100)
+    output_foobar = executor(client, 'ip address show foobar')
+    assert ('foobar@eth1' in output_foobar)
+
+    # Verify Bridging
+    output_eth2 = executor(client, 'ip address show eth2')
+    assert ('master br0' in output_eth2)
+    output_br0 = executor(client, 'ip address show br0')
+    assert ('inet 192.168.122' in output_br0)
+
+    # Verify NIC bonding
+    output_bond0 = executor(client, 'ip address show bond0')
+    assert ('inet 192.168.122.252' in output_bond0)
+    output_bond_mode = executor(client, 'cat /sys/class/net/bond0/bonding/mode')
+    assert ('active-backup 1' in output_bond_mode)
+    output_eth3 = executor(client, 'ip address show eth3')
+    assert ('master bond0' in output_eth3)
+    output_eth4 = executor(client, 'ip address show eth4')
+    client.close()
+    assert ('master bond0' in output_eth4)
+
+
+def test_network_cmds(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}test_network_cmds.yml'.format(url=cloud_config_url),
+                  is_install_to_hard_drive=True, is_network_gist=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    output = executor(client, 'cat /var/log/net.log')
+    net_check_output = '''pre_cmds
+pre_up eth0
+post_up eth0
+pre_up eth1
+post_up eth1
+pre_up eth2
+post_up eth2
+post_cmds
+'''
+    client.close()
+    assert (net_check_output in output)
+
+
+def test_network_boot_cfg(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True,
+                  extra_install_args='--append "rancher.network.interfaces.eth1.address=192.168.122.251/24 '
+                                     'rancher.network.interfaces.eth1.gateway=192.168.122.250 '
+                                     'rancher.network.interfaces.eth0.dhcp=true"', is_network_gist=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    output_eth1 = executor(client, 'ip address show eth1')
+    assert ('inet 192.168.122.251' in output_eth1)
+
+    output_eth1_gw = executor(client, 'ip route show dev eth1')
+    client.close()
+    assert ('default via 192.168.122.250' in output_eth1_gw)
+
+
+def test_network_boot_and_cloud_cfg(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}test_network_boot_and_cloudcfg.yml'.format(url=cloud_config_url),
+                  is_install_to_hard_drive=True,
+                  extra_install_args='--append "rancher.network.interfaces.eth1.address=10.1.0.52/24 '
+                                     'rancher.network.interfaces.eth1.gateway=10.1.0.2 '
+                                     'rancher.network.interfaces.eth0.dhcp=true '
+                                     'rancher.network.interfaces.eth3.dhcp=true"', is_network_gist=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    # This shows that the boot cmdline wins over the cloud-config
+    output_eth1_ip = executor(client, 'ip address show eth1')
+    assert ('inet 10.1.0.52/24' in output_eth1_ip)
+    output_eth1_gw = executor(client, 'ip route show dev eth1')
+    assert ('default via 10.1.0.2' in output_eth1_gw)
+
+    output_eth2_ip = executor(client, 'ip address show eth2')
+    assert ('inet 10.31.168.85/24' in output_eth2_ip)
+    # Known issue https://github.com/rancher/os/issues/2587
+    # output_eth2_gw = executor(client, 'ip route show dev eth2')
+    # assert ('default via 10.31.168.1' in output_eth2_gw)
+
+    output_eth3_ip = executor(client, 'ip address show eth3')
+    client.close()
+    assert ('inet 192.168.122' in output_eth3_ip)
+
+
+def test_network_cloud_cfg(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}test_network_boot_and_cloudcfg.yml'.format(url=cloud_config_url),
+                  is_install_to_hard_drive=True, is_network_gist=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    output_eth1_ip = executor(client, 'ip address show eth1')
+    assert ('inet 10.1.0.41/24' in output_eth1_ip)
+    output_eth1_gw = executor(client, 'ip route show dev eth1')
+    assert ('default via 10.1.0.1' in output_eth1_gw)
+
+    output_eth2_ip = executor(client, 'ip address show eth2')
+    assert ('inet 10.31.168.85/24' in output_eth2_ip)
+    # Known issue https://github.com/rancher/os/issues/2587
+    output_eth2_gw = executor(client, 'ip route show dev eth2')
+    client.close()
+
+    assert ('default via 10.31.168.1' in output_eth2_gw)
+
+
+def test_network_from_url(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True,
+                  extra_install_args=' --append "rancher.cloud_init.datasources=[url:{datasource_url}]"'.format(
+                      datasource_url=data_source_url), is_network_gist=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    output_br0 = executor(client, 'ip addr show br0 ; echo $?')
+    assert ('0' in output_br0)
+
+    output_br0_100 = executor(client, 'ip addr show br0.100')
+    assert ('inet 123.123.123.123' in output_br0_100)
+
+    output_eth1_100 = executor(client, 'ip addr show eth1.100')
+    assert ('master br0' in output_eth1_100)
+
+    c_get_dns = 'cat /etc/resolv.conf'
+    output_dns = executor(client, c_get_dns)
+    client.close()
+    assert ('search mydomain.com example.com' in output_dns)
+    assert ('nameserver 208.67.222.123' in output_dns)
+    assert ('nameserver 208.67.220.123' in output_dns)
+
+
+def test_set_network_from_network_service(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True,
+                  is_network_gist=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    c_set_network = '''
+        echo "rancher:" >> config.yml
+        echo "  network:" >> config.yml
+        echo "    interfaces:" >> config.yml
+        echo "      eth2:" >> config.yml
+        echo "        dhcp: true" >> config.yml
+        echo "      eth3:" >> config.yml
+        echo "        dhcp: false" >> config.yml
+        echo "      eth1:" >> config.yml
+        echo "        address: 192.168.122.253/24" >> config.yml
+        echo "        dhcp: false" >> config.yml
+        echo "        gateway: 192.168.122.254" >> config.yml
+        echo "        mtu: 1500" >> config.yml
+        '''
+    executor(client, c_set_network)
+    executor(client, 'cat config.yml | sudo ros config merge')
+    executor(client, 'sudo ros service restart network && sleep 5')
+    executor(client, 'sleep 2')
+
+    output_eth1 = executor(client, 'ip address show eth1')
+    assert ('inet 192.168.122.253' in output_eth1)
+
+    output_route = executor(client, 'ip route show dev eth1')
+    assert ('default via 192.168.122.254' in output_route)
+
+    output_eth2 = executor(client, 'ip address show eth2')
+    assert ('inet 192.168.122' in output_eth2)
+
+    output_eth3 = executor(client, 'ip address show eth3')
+    client.close()
+    assert ('inet 192.168.122' not in output_eth3)

--- a/engine/test_nonexistent_state.py
+++ b/engine/test_nonexistent_state.py
@@ -1,0 +1,16 @@
+# coding = utf-8
+# Create date: 2018-11-29
+# Author :Hailong
+
+from utils.connect_to_os import executor
+
+
+def test_nonexistent_state(ros_kvm_init):
+    kwargs = dict(kernel_parameters='--no-format '
+                                    'rancher.state.dev=LABEL=NONEXISTENT '
+                                    'rancher.state.autoformat=[/dev/sda,/dev/vda]',
+                  is_kernel_parameters=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    output = executor(client, 'sudo ros config get rancher.state.dev')
+    assert ('LABEL=NONEXISTENT' in output)

--- a/engine/test_swap.py
+++ b/engine/test_swap.py
@@ -11,10 +11,10 @@ def test_swap(ros_kvm_init, cloud_config_url):
 
     tuple_return = ros_kvm_init(**kwargs)
     client = tuple_return[0]
-    client.exec_command('sudo mkswap /dev/vdb && sudo cloud-init-execute', timeout=60)
+    client.exec_command('sudo mkswap /dev/vdb ; sudo cloud-init-execute', timeout=100)
     # Network delay
-    time.sleep(5)
-    stdin, stdout, stderr = client.exec_command('cat /proc/swaps | grep /dev/vdb', timeout=60)
+    time.sleep(30)
+    stdin, stdout, stderr = client.exec_command('cat /proc/swaps | grep /dev/vdb', timeout=100)
     output = stdout.read().decode('utf-8')
     client.close()
     assert ('/dev/vdb' in output)


### PR DESCRIPTION
```(os-test) ksd@hailong-ranchervm-2:~/code$ pytest -n 3 -v engine/test_network.py --junitxml=osTestsJunit.xml
=============================================================== test session starts ================================================================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0 -- /home/ksd/os-test/bin/python3.5
cachedir: .pytest_cache
rootdir: /home/ksd/code, inifile:
plugins: xdist-1.24.1, forked-0.2, cov-2.6.0
[gw0] linux Python 3.5.2 cwd: /home/ksd/code
[gw1] linux Python 3.5.2 cwd: /home/ksd/code
[gw2] linux Python 3.5.2 cwd: /home/ksd/code
[gw0] Python 3.5.2 (default, Nov 23 2017, 16:37:01)  -- [GCC 5.4.0 20160609]
[gw1] Python 3.5.2 (default, Nov 23 2017, 16:37:01)  -- [GCC 5.4.0 20160609]
[gw2] Python 3.5.2 (default, Nov 23 2017, 16:37:01)  -- [GCC 5.4.0 20160609]
gw0 [7] / gw1 [7] / gw2 [7]
scheduling tests via LoadScheduling

engine/test_network.py::test_network_from_cloud_cfg 
engine/test_network.py::test_network_cmds 
engine/test_network.py::test_network_boot_cfg 
[gw2] [ 14%] PASSED engine/test_network.py::test_network_from_cloud_cfg 
[gw1] [ 28%] PASSED engine/test_network.py::test_network_boot_cfg 
engine/test_network.py::test_network_boot_and_cloud_cfg 
engine/test_network.py::test_network_from_url 
[gw0] [ 42%] PASSED engine/test_network.py::test_network_cmds 
engine/test_network.py::test_network_cloud_cfg 
[gw0] [ 57%] PASSED engine/test_network.py::test_network_cloud_cfg 
[gw2] [ 71%] PASSED engine/test_network.py::test_network_boot_and_cloud_cfg 
engine/test_network.py::test_set_network_from_network_service 
[gw1] [ 85%] PASSED engine/test_network.py::test_network_from_url 
[gw2] [100%] PASSED engine/test_network.py::test_set_network_from_network_service 

----------------------------------------------- generated xml file: /home/ksd/code/osTestsJunit.xml ------------------------------------------------
============================================================ 7 passed in 496.70 seconds ============================================================```

-------------------------------------------------------
```(os-test) ksd@hailong-ranchervm-2:~/code$ pytest engine/test_bad_state.py 
============================================================ test session starts ============================================================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /home/ksd/code, inifile:
plugins: xdist-1.24.1, forked-0.2, cov-2.6.0
collected 2 items                                                                                                                           

engine/test_bad_state.py ..                                                                                                           [100%]

======================================================== 2 passed in 197.06 seconds =========================================================```

-----------------------------------------------
```