### PR TITLE
Add test case for ros cli

### DIFF
--- a/engine/test_cli.py
+++ b/engine/test_cli.py
@@ -1,0 +1,30 @@
+# coding = utf-8
+# Create date: 2019-4-1
+# Author :Hailong
+
+from utils.connect_to_os import executor
+
+
+def test_cli_config_merge(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    c_set_console = '''
+        echo "#cloud-config" >> config.yml
+        echo "rancher: " >> config.yml
+        echo "  console: debian" >> config.yml
+        '''
+    executor(client, c_set_console)
+    executor(client, 'cat config.yml | sudo ros config merge')
+    output_get_console = executor(client, 'sudo ros config get rancher.console')
+    assert ('debian' in output_get_console)
+
+    c_set_debug = '''
+        echo "#cloud-config" >> config1.yml
+        echo "rancher: " >> config1.yml
+        echo "  debug: true" >> config1.yml
+        '''
+    executor(client, c_set_debug)
+    executor(client, 'sudo ros config merge -i config1.yml')
+    output_get_debug = executor(client, 'sudo ros config get rancher.debug')
+    assert ('true' in output_get_debug)


### PR DESCRIPTION
```
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /opt/os-test_project, inifile:
plugins: xdist-1.24.1, forked-0.2, cov-2.6.0
collected 1 item                                                               

engine/test_cli.py Formatting '/opt/os-tests/images/3U17FZZ3.qcow2', fmt=qcow2 size=10737418240 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
.

========================== 1 passed in 131.22 seconds ==========================

Process finished with exit code 0
```