### PR TITLE
Add test case for ssh config

### DIFF
--- a/engine/test_ssh_config.py
+++ b/engine/test_ssh_config.py
@@ -1,0 +1,38 @@
+# coding = utf-8
+# Create date: 2019-4-2
+# Author: Hailong
+# Issue: https://github.com/rancher/os/issues/2581
+
+from utils.connect_to_os import executor, connection
+
+
+def test_check_ssh_config_when_reboot(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    ip = tuple_return[1]
+    output = executor(client, 'sudo ros console list | grep -v default')
+    list_of_console = output.split('\n')
+    list_of_console.pop(-1)
+
+    console_list = []
+
+    for console in list_of_console:
+        console_list.append(console.split(' ')[1])
+
+    for console_v in console_list:
+        client = connection(ip, None)
+        executor(client, 'sudo ros console switch -f {console_version}'.format(console_version=console_v))
+        client = connection(ip, None)
+        executor(client, 'sudo reboot')
+        client = connection(ip, None)
+        output_get_current_console = executor(client, 'sudo ros console list | grep current')
+
+        assert (console_v in output_get_current_console)
+
+        ssh_config_items = ['UseDNS no', 'PermitRootLogin no', 'ServerKeyBits 2048', 'AllowGroups docker']
+        for ssh_config_item in ssh_config_items:
+            output_ssh_config = executor(client, 'grep "^{ssh_config_item}" /etc/ssh/sshd_config | wc -l'.format(
+                ssh_config_item=ssh_config_item)).replace('\n', '')
+
+            assert (int(output_ssh_config) <= 1)


### PR DESCRIPTION
#### Related issue:
https://github.com/rancher/os/issues/2581


```
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /tmp/pycharm_project_699, inifile:
plugins: cov-2.6.0
collected 1 item                                                               

engine/test_ssh_config.py Formatting '/opt/os-tests/images/Z4EW517D.qcow2', fmt=qcow2 size=10737418240 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
.

========================== 1 passed in 448.37 seconds ==========================

Process finished with exit code 0

```