### PR TITLE
Add test case for get ssh_authorized_keys

### DIFF
--- a/engine/test_ros_config.py
+++ b/engine/test_ros_config.py
@@ -3,6 +3,9 @@
 # Author :Hailong
 
 
+from utils.connect_to_os import executor
+
+
 def test_ros_config(ros_kvm_init, cloud_config_url):
     fb_cc_hostname = 'hostname3'
     command_cc_hostname = 'sudo ros config get hostname'
@@ -86,6 +89,15 @@ def test_ros_config(ros_kvm_init, cloud_config_url):
     output_cli_get_export = _get_full_export(client)
     client.close()
     assert (fb_cli_labels in output_cli_get_export)
+
+
+def test_ros_config_ssh_authorized_keys(ros_kvm_init, cloud_config_url):
+    kwargs = dict(cloud_config='{url}default.yml'.format(url=cloud_config_url), is_install_to_hard_drive=True)
+    tuple_return = ros_kvm_init(**kwargs)
+    client = tuple_return[0]
+    output_get_ssh_authkey = executor(client, 'sudo ros config get ssh_authorized_keys')
+    output_cat_ssh_authkey = executor(client, 'cat ~/.ssh/authorized_keys')
+    assert (output_cat_ssh_authkey in output_get_ssh_authkey)
 
 
 def _get_export(client):

--- a/engine/test_ssh_key_merge.py
+++ b/engine/test_ssh_key_merge.py
@@ -16,7 +16,7 @@ def test_ssh_key_merge(ros_kvm_init, cloud_config_url):
                    '> /var/lib/rancher/conf/metadata'
 
     set_ssh_aut_key = 'echo -e ' \
-                      '"$(sudo ros config get ssh_authorized_keys | head -2)\n- zero\n- one\n- two\n" ' \
+                      '"$(sudo ros config get ssh_authorized_keys | head -1)\n- zero\n- one\n- two\n" ' \
                       '> expected'
 
     set_current = 'sudo ros config get ssh_authorized_keys > current_config'


### PR DESCRIPTION
Related issue:
https://github.com/rancher/os/issues/2579

```
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /opt/os-test_project, inifile:
plugins: xdist-1.24.1, forked-0.2, cov-2.6.0
collected 1 item                                                               

engine/test_ros_config.py Formatting '/opt/os-tests/images/BQB4PNSZ.qcow2', fmt=qcow2 size=10737418240 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
.

========================== 1 passed in 137.99 seconds ==========================

Process finished with exit code 0


============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /opt/os-test_project, inifile:
plugins: xdist-1.24.1, forked-0.2, cov-2.6.0
collected 1 item                                                               

engine/test_ssh_key_merge.py Formatting '/opt/os-tests/images/AJKQWHMI.qcow2', fmt=qcow2 size=10737418240 encryption=off cluster_size=65536 lazy_refcounts=off refcount_bits=16
.

========================== 1 passed in 288.53 seconds ==========================

Process finished with exit code 0
```